### PR TITLE
fix: pagefind output path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "start": "hugo serve --logLevel info --configDir=config --buildDrafts --buildFuture --ignoreCache --disableFastRender --gc  --printI18nWarnings --printMemoryUsage --printPathWarnings --printUnusedTemplates --templateMetrics --templateMetricsHints",
       "dev": "npm run dev:start",
       "dev:start": "hugo serve --logLevel info --configDir=config --buildDrafts --buildFuture --ignoreCache --disableFastRender --gc  --printI18nWarnings --printMemoryUsage --printPathWarnings --printUnusedTemplates --templateMetrics --templateMetricsHints",
-      "dev:start:with-pagefind": "hugo --baseURL=/ --theme=dot-org-hugo-theme && npm_config_yes=true npx pagefind --site 'public' --output-subdir 'static/pagefind' && npm run dev:start",
+      "dev:start:with-pagefind": "hugo --baseURL=/ --theme=dot-org-hugo-theme && npm_config_yes=true npx pagefind --site 'public' --output-path 'static/pagefind' && npm run dev:start",
       "dev:build": "hugo --theme=dot-org-hugo-theme"
   },
   "repository": {


### PR DESCRIPTION
### Description

It's preferable to output in the static folder directly instead of the site folder.

### Change

Replaced `--output-subdir` by `--output-path` for more control.